### PR TITLE
fix(types): rewrite .d.mts relative specifiers to .mjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5304,9 +5304,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -5324,7 +5324,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/ts-toolkit",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/ts-toolkit",
-      "version": "5.0.0-beta.0",
+      "version": "5.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/ts-toolkit",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "description": "This cli facilitates the creation of boilerplate files in a new typescript repo",
   "repository": "https://github.com/MakerXStudio/ts-toolkit",
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ For TypeScript to honour those conditions, the `.d.mts` and `.d.cts` files actua
 - `*.d.cts` — byte-for-byte copy of `*.d.ts`. CJS resolution accepts extensionless relative specifiers, so no rewriting is needed.
 - `*.d.mts` — copy with relative specifiers rewritten so the resolver pairs each declaration with its `.d.mts` twin rather than the `.d.ts`. Concretely:
   - `from './foo'` → `from './foo.mjs'` (when `./foo.d.ts` or `./foo.d.mts` exists)
-  - `from './foo'` → `from './foo/index.mjs'` (when `./foo/index.d.ts` exists)
+  - `from './foo'` → `from './foo/index.mjs'` (when `./foo/index.d.ts` or `./foo/index.d.mts` exists)
   - `from './foo.js'`, `from 'some-package'`, and unresolvable paths are left alone.
 
 The reason for `.mjs` (not `.js`): under `moduleResolution: "node16"`/`"nodenext"`, a `.js` specifier inside a `.d.mts` resolves against the adjacent `.d.ts`, which in a dual-published package whose root `package.json` has `"type": "commonjs"` is treated as CJS-flavoured. Strict-ESM consumers then surface type-resolution mismatches. Using `.mjs` keeps the resolution chain in ESM throughout.

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,31 @@ export default config
 
 File paths used in this config file should point to the typescript file relative to the source directory. The tool will translate this to relevant js/mjs/d.ts paths in the out directory.
 
+### Dual type declarations (`exportTypes: 'both'`)
+
+When `exportTypes` is `'both'`, the rewritten `package.json` declares per-condition `types` so each consumer resolves declarations in their own module system:
+
+```jsonc
+"exports": {
+  ".": {
+    "import":  { "types": "./index.d.mts", "default": "./index.mjs" },
+    "require": { "types": "./index.d.cts", "default": "./index.js"  }
+  }
+}
+```
+
+For TypeScript to honour those conditions, the `.d.mts` and `.d.cts` files actually have to exist. `copy-package-json` produces them by duplicating each `.d.ts` emitted by the build:
+
+- `*.d.cts` — byte-for-byte copy of `*.d.ts`. CJS resolution accepts extensionless relative specifiers, so no rewriting is needed.
+- `*.d.mts` — copy with relative specifiers rewritten so the resolver pairs each declaration with its `.d.mts` twin rather than the `.d.ts`. Concretely:
+  - `from './foo'` → `from './foo.mjs'` (when `./foo.d.ts` or `./foo.d.mts` exists)
+  - `from './foo'` → `from './foo/index.mjs'` (when `./foo/index.d.ts` exists)
+  - `from './foo.js'`, `from 'some-package'`, and unresolvable paths are left alone.
+
+The reason for `.mjs` (not `.js`): under `moduleResolution: "node16"`/`"nodenext"`, a `.js` specifier inside a `.d.mts` resolves against the adjacent `.d.ts`, which in a dual-published package whose root `package.json` has `"type": "commonjs"` is treated as CJS-flavoured. Strict-ESM consumers then surface type-resolution mismatches. Using `.mjs` keeps the resolution chain in ESM throughout.
+
+If your build already emits `.d.mts`/`.d.cts` directly, `copy-package-json` won't overwrite them — duplication only fills in missing siblings.
+
 ## Sub-Packages
 
 ### @makerx/eslint-config

--- a/src/templates/node/rollup.config.ts.sample
+++ b/src/templates/node/rollup.config.ts.sample
@@ -4,6 +4,9 @@ import typescript from '@rollup/plugin-typescript'
 import json from '@rollup/plugin-json'
 import type { RollupOptions } from 'rollup'
 
+const isBareModuleImport = (id: string, importer: string | undefined) =>
+  importer !== undefined && !id.startsWith('.') && !isAbsolute(id)
+
 const config: RollupOptions = {
   input: ['src/index.ts'],
   output: [
@@ -29,7 +32,7 @@ const config: RollupOptions = {
     moduleSideEffects: false,
     propertyReadSideEffects: false,
   },
-  external: [/node_modules/],
+  external: isBareModuleImport,
   plugins: [
     typescript({
       tsconfig: 'tsconfig.build.json',

--- a/src/templates/node/rollup.config.ts.sample
+++ b/src/templates/node/rollup.config.ts.sample
@@ -14,6 +14,7 @@ const config: RollupOptions = {
       exports: 'named',
       preserveModules: true,
       sourcemap: true,
+      interop: 'auto',
     },
     {
       dir: 'dist',

--- a/src/util/copy-package-json-from-config.spec.ts
+++ b/src/util/copy-package-json-from-config.spec.ts
@@ -51,6 +51,12 @@ describe('rewriteEsmRelativeImports', () => {
     expect(rewriteEsmRelativeImports(`from './esm-only'`, dir)).toBe(`from './esm-only.mjs'`)
   })
 
+  it('Resolves directory specifiers when only an index.d.mts is present', () => {
+    fs.mkdirSync(path.join(dir, 'esm-sub'))
+    fs.writeFileSync(path.join(dir, 'esm-sub', 'index.d.mts'), '', 'utf-8')
+    expect(rewriteEsmRelativeImports(`from './esm-sub'`, dir)).toBe(`from './esm-sub/index.mjs'`)
+  })
+
   it('Rewrites all three module-specifier shapes in one pass', () => {
     fs.writeFileSync(path.join(dir, 'helper.d.ts'), '', 'utf-8')
     const input = [`import { x } from './helper'`, `import './helper'`, `type T = typeof import('./helper').x`].join('\n')

--- a/src/util/copy-package-json-from-config.spec.ts
+++ b/src/util/copy-package-json-from-config.spec.ts
@@ -35,10 +35,27 @@ describe('rewriteEsmRelativeImports', () => {
     expect(rewriteEsmRelativeImports(input, dir)).toBe(input)
   })
 
+  it('Resolves file specifiers to .mjs so the .d.mts twin is paired under node16+ resolution', () => {
+    fs.writeFileSync(path.join(dir, 'helper.d.ts'), '', 'utf-8')
+    expect(rewriteEsmRelativeImports(`from './helper'`, dir)).toBe(`from './helper.mjs'`)
+  })
+
   it('Resolves directory specifiers to /index.mjs', () => {
     fs.mkdirSync(path.join(dir, 'sub'))
     fs.writeFileSync(path.join(dir, 'sub', 'index.d.ts'), '', 'utf-8')
     expect(rewriteEsmRelativeImports(`from './sub'`, dir)).toBe(`from './sub/index.mjs'`)
+  })
+
+  it('Resolves when only a .d.mts twin exists alongside the source', () => {
+    fs.writeFileSync(path.join(dir, 'esm-only.d.mts'), '', 'utf-8')
+    expect(rewriteEsmRelativeImports(`from './esm-only'`, dir)).toBe(`from './esm-only.mjs'`)
+  })
+
+  it('Rewrites all three module-specifier shapes in one pass', () => {
+    fs.writeFileSync(path.join(dir, 'helper.d.ts'), '', 'utf-8')
+    const input = [`import { x } from './helper'`, `import './helper'`, `type T = typeof import('./helper').x`].join('\n')
+    const expected = [`import { x } from './helper.mjs'`, `import './helper.mjs'`, `type T = typeof import('./helper.mjs').x`].join('\n')
+    expect(rewriteEsmRelativeImports(input, dir)).toBe(expected)
   })
 
   it('Leaves specifiers that cannot be resolved alone', () => {

--- a/src/util/copy-package-json-from-config.spec.ts
+++ b/src/util/copy-package-json-from-config.spec.ts
@@ -35,10 +35,10 @@ describe('rewriteEsmRelativeImports', () => {
     expect(rewriteEsmRelativeImports(input, dir)).toBe(input)
   })
 
-  it('Resolves directory specifiers to /index.js', () => {
+  it('Resolves directory specifiers to /index.mjs', () => {
     fs.mkdirSync(path.join(dir, 'sub'))
     fs.writeFileSync(path.join(dir, 'sub', 'index.d.ts'), '', 'utf-8')
-    expect(rewriteEsmRelativeImports(`from './sub'`, dir)).toBe(`from './sub/index.js'`)
+    expect(rewriteEsmRelativeImports(`from './sub'`, dir)).toBe(`from './sub/index.mjs'`)
   })
 
   it('Leaves specifiers that cannot be resolved alone', () => {
@@ -190,14 +190,14 @@ describe('copyPackageJsonFromConfig', () => {
     })
 
     const mtsContents = fs.readFileSync(path.join(outDir, 'index.d.mts'), 'utf-8')
-    expect(mtsContents).toContain(`from './util/helper.js'`)
-    expect(mtsContents).toContain(`import('./util/helper.js')`)
+    expect(mtsContents).toContain(`from './util/helper.mjs'`)
+    expect(mtsContents).toContain(`import('./util/helper.mjs')`)
     expect(mtsContents).not.toContain(`from './util/helper'`)
 
     // The .d.cts should be content-identical to the original .d.ts
     const ctsContents = fs.readFileSync(path.join(outDir, 'index.d.cts'), 'utf-8')
     expect(ctsContents).toContain(`from './util/helper'`)
-    expect(ctsContents).not.toContain(`from './util/helper.js'`)
+    expect(ctsContents).not.toContain(`from './util/helper.mjs'`)
   })
 
   it('Does not emit dual declarations in single-flavor modes', () => {

--- a/src/util/copy-package-json-from-config.ts
+++ b/src/util/copy-package-json-from-config.ts
@@ -119,8 +119,8 @@ function emitIfMissing(destination: string, produceContent: () => string): numbe
 }
 
 // Rewrites relative specifiers in a declaration file for ESM resolution:
-//   from './x'        → from './x.mjs'          (when ./x.d.ts exists)
-//   from './x'        → from './x/index.mjs'    (when ./x/index.d.ts exists)
+//   from './x'        → from './x.mjs'          (when ./x.d.ts or ./x.d.mts exists)
+//   from './x'        → from './x/index.mjs'    (when ./x/index.d.ts or ./x/index.d.mts exists)
 // The .mjs extension pairs the specifier with the adjacent .d.mts declaration
 // under TS's node16+ resolver; using .js would resolve against the .d.ts
 // (CJS-flavoured in a dual-published package) and surface as type errors in

--- a/src/util/copy-package-json-from-config.ts
+++ b/src/util/copy-package-json-from-config.ts
@@ -87,9 +87,10 @@ function buildExportEntry(value: string, exportTypes: ExportType) {
 
 // Produces .d.mts and .d.cts siblings for every .d.ts in outDir so ESM and
 // CJS consumers each resolve types in their own module system. The .d.mts copy
-// has its extensionless relative imports rewritten to `.js` — TS's node16+ ESM
-// resolution requires explicit extensions on relative specifiers. The .d.cts
-// copy can be content-identical since CJS resolution tolerates either form.
+// has its extensionless relative imports rewritten to `.mjs` so that TS's
+// node16+ ESM resolution pairs each declaration with its .d.mts twin rather
+// than the CJS-flavoured .d.ts. The .d.cts copy can be content-identical
+// since CJS resolution tolerates extensionless specifiers.
 function emitDualDeclarations(outDir: string) {
   if (!fs.existsSync(outDir)) return
   let emitted = 0
@@ -118,11 +119,14 @@ function emitIfMissing(destination: string, produceContent: () => string): numbe
 }
 
 // Rewrites relative specifiers in a declaration file for ESM resolution:
-//   from './x'        → from './x.js'           (when ./x.d.ts exists)
-//   from './x'        → from './x/index.js'     (when ./x/index.d.ts exists)
-// Non-relative specifiers, already-extensioned specifiers, and unresolvable
-// paths are left alone. Covers `from '...'`, bare `import '...'`, and
-// dynamic `import('...')` forms — the shapes that appear in .d.ts output.
+//   from './x'        → from './x.mjs'          (when ./x.d.ts exists)
+//   from './x'        → from './x/index.mjs'    (when ./x/index.d.ts exists)
+// The .mjs extension pairs the specifier with the adjacent .d.mts declaration
+// under TS's node16+ resolver; using .js would resolve against the .d.ts
+// (CJS-flavoured in a dual-published package) and surface as type errors in
+// strict ESM consumers. Non-relative specifiers, already-extensioned
+// specifiers, and unresolvable paths are left alone. Covers `from '...'`,
+// bare `import '...'`, and dynamic `import('...')` forms.
 export function rewriteEsmRelativeImports(source: string, sourceDir: string): string {
   const patterns = [
     /(\bfrom\s*)(['"])(\.{1,2}\/[^'"]+)\2/g,
@@ -142,9 +146,9 @@ export function rewriteEsmRelativeImports(source: string, sourceDir: string): st
 function rewriteSpecifier(spec: string, sourceDir: string): string | null {
   if (/\.(m?js|cjs|json|node|d\.m?ts|d\.cts|tsx?|jsx?)$/i.test(spec)) return null
   const candidate = path.resolve(sourceDir, spec)
-  if (fs.existsSync(`${candidate}.d.ts`) || fs.existsSync(`${candidate}.d.mts`)) return `${spec}.js`
+  if (fs.existsSync(`${candidate}.d.ts`) || fs.existsSync(`${candidate}.d.mts`)) return `${spec}.mjs`
   if (fs.existsSync(path.join(candidate, 'index.d.ts')) || fs.existsSync(path.join(candidate, 'index.d.mts'))) {
-    return spec.endsWith('/') ? `${spec}index.js` : `${spec}/index.js`
+    return spec.endsWith('/') ? `${spec}index.mjs` : `${spec}/index.mjs`
   }
   return null
 }


### PR DESCRIPTION
## Summary

Follow-up to #120. `emitDualDeclarations` was producing `.d.mts` files whose relative specifiers ended in `.js`, which under TS's node16+ ESM resolver pairs them with the adjacent `.d.ts`. In a dual-published package whose root `package.json` has `"type": "commonjs"`, that `.d.ts` is treated as CJS-flavoured — so strict-ESM consumers see type-resolution mismatches against an otherwise-valid package.

`rewriteSpecifier` is only ever called from the `.d.mts` branch of `emitDualDeclarations`, so the extension it emits should be `.mjs`, which pairs with the `.d.mts` twin and keeps the resolution chain in ESM throughout. The `.d.cts` branch is unaffected.

### What changed

- `src/util/copy-package-json-from-config.ts` — two-character fix in `rewriteSpecifier` (`.js` → `.mjs` in both the file and directory branches), plus updated comments explaining the rationale.
- `src/util/copy-package-json-from-config.spec.ts` — updated the three existing assertions that pinned the buggy `.js` output, then added focused coverage for: the file case (was only exercised via the integration test), resolving when only the `.d.mts` twin exists, and exercising all three module-specifier shapes (`from '...'`, bare `import '...'`, dynamic `import('...')`) in one pass.
- `readme.md` — added a `## copy-package-json` subsection covering dual-declaration emission, the per-condition `exports` shape, and the `.mjs` rewrite rules with rationale. The original feature shipped without README coverage; this fills that gap.

### Discovered via

Building [@makerx/graphql-apollo-server@2.0.0-beta.0](https://github.com/MakerXStudio/graphql-apollo-server) against the just-published `@makerx/ts-toolkit@5.0.0-beta.0` produced `.d.mts` files like:

```ts
// dist/index.d.mts
export * from './plugins/index.js'   // ← resolves to dist/plugins/index.d.ts (CJS-flavoured)
```

Strict-NodeNext consumers downstream see mis-resolved declarations. After this fix:

```ts
// dist/index.d.mts
export * from './plugins/index.mjs'  // ← resolves to dist/plugins/index.d.mts (ESM)
```

## Why `.mjs` rather than `.js`

Under `moduleResolution: "node16"`/`"nodenext"`, TypeScript pairs each module specifier with the declaration whose extension matches the JS extension:

| Specifier in `.d.mts` | Resolves to        | Module kind in dual-publish dist |
|-----------------------|--------------------|----------------------------------|
| `'./foo.js'`          | `./foo.d.ts`       | CJS (per `package.json` type)    |
| `'./foo.mjs'`         | `./foo.d.mts`      | ESM                              |

Using `.mjs` keeps the entire declaration chain in one module kind, so ESM consumers don't accidentally pull in CJS-shaped types.

## Test plan

- [x] `npm test` — 17/17 pass (was 14, added 3)
- [x] `npm run build` — ts-toolkit dogfoods: its own `dist/index.d.mts` now reads `from './util/copy-package-json-from-config.mjs'`
- [x] `attw --pack dist` — green across node10 / node16 (CJS) / node16 (ESM) / bundler (caveat: attw doesn't actually validate this class of fix, so the byte-level inspection is the real verification)
- [ ] Rebuild a downstream dual-publish consumer (e.g. graphql-apollo-server) against this branch and confirm its `.d.mts` files now use `.mjs` specifiers without any local workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also - use rollup `interop: 'auto'` for CJS output

<img width="746" height="659" alt="image" src="https://github.com/user-attachments/assets/00299a92-d998-4e58-a7ec-6fd6cb75b40d" />

## Also - fix rollup external package identifier